### PR TITLE
Kotlin - Exercise 2

### DIFF
--- a/kotlin/TextConverter/src/main/kotlin/tddmicroexercises/textconvertor/HtmlPagesConverter.kt
+++ b/kotlin/TextConverter/src/main/kotlin/tddmicroexercises/textconvertor/HtmlPagesConverter.kt
@@ -1,48 +1,15 @@
 package tddmicroexercises.textconvertor
 
-import java.io.BufferedReader
-import java.io.FileReader
 import java.io.IOException
-import java.util.ArrayList
+import java.io.StringReader
 
-class HtmlPagesConverter @Throws(IOException::class)
-constructor(val filename: String) {
-    private val breaks = ArrayList<Int>()
-
-    init {
-
-        this.breaks.add(0)
-        val reader = BufferedReader(FileReader(this.filename))
-        var cumulativeCharCount = 0
-        var line: String? = reader.readLine()
-        while (line != null) {
-            cumulativeCharCount += line.length + 1 // add one for the newline
-            if (line.contains("PAGE_BREAK")) {
-                val page_break_position = cumulativeCharCount
-                breaks.add(page_break_position)
-            }
-            line = reader.readLine()
-        }
-        reader.close()
-    }
+class HtmlPagesConverter(htmlContent: String) {
+    private val pages = htmlContent.split("\nPAGE_BREAK\n")
 
     @Throws(IOException::class)
     fun getHtmlPage(page: Int): String {
-        val reader = BufferedReader(FileReader(this.filename))
-        reader.skip(breaks[page].toLong())
-        val htmlPage = StringBuffer()
-        var line: String? = reader.readLine()
-        while (line != null) {
-            if (line.contains("PAGE_BREAK")) {
-                break
-            }
-            htmlPage.append(StringEscapeUtils.escapeHtml(line))
-            htmlPage.append("<br />")
-
-            line = reader.readLine()
-        }
-        reader.close()
-        return htmlPage.toString()
+        val htmlPage = pages[page]
+        val converter = HtmlTextConverter(StringReader(htmlPage))
+        return converter.convertToHtml()
     }
-
 }

--- a/kotlin/TextConverter/src/main/kotlin/tddmicroexercises/textconvertor/HtmlTextConverter.kt
+++ b/kotlin/TextConverter/src/main/kotlin/tddmicroexercises/textconvertor/HtmlTextConverter.kt
@@ -1,24 +1,18 @@
 package tddmicroexercises.textconvertor
 
 import java.io.BufferedReader
-import java.io.FileReader
 import java.io.IOException
+import java.io.Reader
+import kotlin.streams.toList
 
-class HtmlTextConverter(val filename: String) {
+class HtmlTextConverter(private val reader: Reader) {
 
     @Throws(IOException::class)
     fun convertToHtml(): String {
-
-        val reader = BufferedReader(FileReader(filename))
-
-        var line: String? = reader.readLine()
-        var html = ""
-        while (line != null) {
-            html += StringEscapeUtils.escapeHtml(line)
-            html += "<br />"
-            line = reader.readLine()
-        }
-        return html
-
+        return BufferedReader(reader)
+                .lines()
+                .map(StringEscapeUtils::escapeHtml)
+                .toList()
+                .joinToString("<br />", postfix = "<br />")
     }
 }

--- a/kotlin/TextConverter/src/test/kotlin/tddmicroexercises/textconvertor/HtmlPagesConverterTest.kt
+++ b/kotlin/TextConverter/src/test/kotlin/tddmicroexercises/textconvertor/HtmlPagesConverterTest.kt
@@ -1,15 +1,55 @@
 package tddmicroexercises.textconvertor
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.io.IOException
-
-import org.junit.Assert.*
 
 class HtmlPagesConverterTest {
     @Test
     @Throws(IOException::class)
-    fun foo() {
-        val converter = HtmlPagesConverter("foo")
-        assertEquals("fixme", converter.filename)
+    fun `Convert ampersand symbol`() {
+        val converter = createHtmlPageConvertWithText("copy & paste")
+        assertEquals("copy &amp; paste<br />", converter.getHtmlPage(0))
+    }
+
+    @Test
+    fun `Convert less then symbol`() {
+        val converter = createHtmlPageConvertWithText("5 < 6")
+        assertEquals("5 &lt; 6<br />", converter.getHtmlPage(0))
+    }
+
+    @Test
+    fun `Convert greater then symbol`() {
+        val converter = createHtmlPageConvertWithText("10 > 3")
+        assertEquals("10 &gt; 3<br />", converter.getHtmlPage(0))
+    }
+
+    @Test
+    fun `Convert double quote`() {
+        val converter = createHtmlPageConvertWithText("\"Bonjour\"")
+        assertEquals("&quot;Bonjour&quot;<br />", converter.getHtmlPage(0))
+    }
+
+    @Test
+    fun `Convert single quote`() {
+        val converter = createHtmlPageConvertWithText("'Bonjour'")
+        assertEquals("&quot;Bonjour&quot;<br />", converter.getHtmlPage(0))
+    }
+
+    @Test
+    fun `Convert multiline`() {
+        val converter = createHtmlPageConvertWithText("test1\ntest2\ntest3")
+        assertEquals("test1<br />test2<br />test3<br />", converter.getHtmlPage(0))
+    }
+
+    @Test
+    fun `Split into two pages when PAGE_BREAK`() {
+        val converter = createHtmlPageConvertWithText("test1\nPAGE_BREAK\ntest2")
+        assertEquals("test1<br />", converter.getHtmlPage(0))
+        assertEquals("test2<br />", converter.getHtmlPage(1))
+    }
+
+    private fun createHtmlPageConvertWithText(text: String): HtmlPagesConverter {
+        return HtmlPagesConverter(text)
     }
 }

--- a/kotlin/TextConverter/src/test/kotlin/tddmicroexercises/textconvertor/HtmlTextConverterTest.kt
+++ b/kotlin/TextConverter/src/test/kotlin/tddmicroexercises/textconvertor/HtmlTextConverterTest.kt
@@ -1,12 +1,53 @@
 package tddmicroexercises.textconvertor
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.StringReader
+import java.nio.file.Files
 
 class HtmlTextConverterTest {
+
     @Test
-    fun foo() {
-        val converter = HtmlTextConverter("foo")
-        assertEquals("fixme", converter.filename)
+    fun `Convert ampersand symbol`() {
+        val converter = createHtmlConverterWithText("copy & paste")
+        assertEquals("copy &amp; paste<br />", converter.convertToHtml())
+    }
+
+    @Test
+    fun `Convert less then symbol`() {
+        val converter = createHtmlConverterWithText("5 < 6")
+        assertEquals("5 &lt; 6<br />", converter.convertToHtml())
+    }
+
+    @Test
+    fun `Convert greater then symbol`() {
+        val converter = createHtmlConverterWithText("10 > 3")
+        assertEquals("10 &gt; 3<br />", converter.convertToHtml())
+    }
+
+    @Test
+    fun `Convert double quote`() {
+        val converter = createHtmlConverterWithText("\"Bonjour\"")
+        assertEquals("&quot;Bonjour&quot;<br />", converter.convertToHtml())
+    }
+
+    @Test
+    fun `Convert single quote`() {
+        val converter = createHtmlConverterWithText("'Bonjour'")
+        assertEquals("&quot;Bonjour&quot;<br />", converter.convertToHtml())
+    }
+
+    @Test
+    fun `Convert multiline`() {
+        val converter = createHtmlConverterWithText("test1\ntest2\ntest3")
+        assertEquals("test1<br />test2<br />test3<br />", converter.convertToHtml())
+    }
+
+    private fun createHtmlConverterWithText(text: String): HtmlTextConverter {
+        return HtmlTextConverter(reader = StringReader(text))
     }
 }


### PR DESCRIPTION
> UnicodeFileToHtmlTextConverter exercise: write the unit tests for the UnicodeFileToHtmlTextConverter class. The UnicodeFileToHtmlTextConverter class is designed to reformat a plain text file for display in a browser. For the Python and Java versions, there is an additional class "HtmlPagesConverter" which is slightly harder to get under test. It not only converts text in a file to html, it also supports pagination. It's meant as a follow up exercise.